### PR TITLE
fix header responsive

### DIFF
--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -5,13 +5,13 @@ import { Countdown } from "~/components/Countdown";
 export default function Home() {
   return (
     <>
-      <div class="flex flex-col md:flex-row md:mx-auto max-w-6xl w-full font-bold items-center my-10 md:my-0 md:h-[50vh] justify-between p-4">
-        <div class="text-5xl md:text-[5rem] leading-0 text-hackblue border-l-8 md:py-7 pl-7 border-hackblue">
+      <div class="flex flex-col min-[895px]:flex-row min-[895px]:mx-auto max-w-6xl w-full font-bold items-center my-10 min-[895px]:my-0 min-[895px]:h-[50vh] justify-between p-4">
+        <h1 class="text-[min(11vw,48px)] md:text-[5rem] leading-[1.2em] md:leading-[0.7em] text-hackblue border-l-8 md:py-7 pl-7 border-hackblue">
           <div>
             Solid<span class="text-gray-500">Hack</span>
             <span class="text-gray-400 font-medium">2024</span>
           </div>
-        </div>
+        </h1>
         <img
           class="w-20 md:w-40"
           src="/img/logo-mark.png"


### PR DESCRIPTION
Before:
<img width="324" alt="Screenshot 2024-09-03 at 7 46 12 PM" src="https://github.com/user-attachments/assets/6b92302b-6e31-4e1c-9e0e-898168c5b657">



After:
<img width="378" alt="Screenshot 2024-09-03 at 7 45 53 PM" src="https://github.com/user-attachments/assets/19e20cd7-39b7-4069-8a17-3fd5a1736a46">


Changed md breakpoint to 895px to prevent this V
<img width="398" alt="Screenshot 2024-09-03 at 7 46 52 PM" src="https://github.com/user-attachments/assets/540bf545-80cf-457a-a3eb-e0795178ccfd">


